### PR TITLE
More A2S features

### DIFF
--- a/include/game-host-adapter/c_api.h
+++ b/include/game-host-adapter/c_api.h
@@ -395,9 +395,9 @@ extern "C"
         uint8_t server_type;
         /// Environment the server is running in. Currently 'w' for Windows, 'l' for Linux, 'm' for Mac
         uint8_t environment;
-        /// Visibility of the server. Currently '0' for public and '1' for private
+        /// Visibility of the server. Currently 0 for public and 1 for private
         uint8_t visibility;
-        /// Anti-cheat running on the server. Currently '0' for unsecured, '1' for secured
+        /// Anti-cheat running on the server. Currently 0 for unsecured, 1 for secured
         uint8_t anticheat;
         /// Version of the game installed on the server
         const char* version;

--- a/include/test-helpers/a2s.hpp
+++ b/include/test-helpers/a2s.hpp
@@ -17,6 +17,7 @@ limitations under the License.
 #define GAME_HOST_ADAPTER_INTERFACE_A2S_HPP
 
 #include "rh_string.h"
+#include "rh_vector.h"
 #include "boost/core/span.hpp"
 
 #include "boost/endian/conversion.hpp"
@@ -109,6 +110,10 @@ struct a2s_challenge_response
         }
 
         A2SDatagram(rallyhere::string& data) : Data(reinterpret_cast<uint8_t*>(data.data()), data.size()), next(std::begin(Data))
+        {
+        }
+
+        A2SDatagram(rallyhere::vector<uint8_t>& data) : Data(data.data(), data.size()), next(std::begin(Data))
         {
         }
 

--- a/include/test-helpers/a2s.hpp
+++ b/include/test-helpers/a2s.hpp
@@ -69,11 +69,26 @@ namespace rallyhere
     };
 #pragma pack(pop)
 
+#pragma pack(push, 1)
+struct a2s_challenge_response
+{
+    int32_t header;
+    uint8_t type;
+    int32_t challenge;
+};
+#pragma pack(pop)
+
     enum class a2s_query : uint8_t
     {
         info = 0x54,
         players = 0x55,
         rules = 0x56,
+    };
+
+    enum a2s_response_type : uint8_t
+    {
+        info = 0x49,
+        challenge = 0x41,
     };
 
     struct A2SDatagram
@@ -90,6 +105,10 @@ namespace rallyhere
 
         template<typename Element>
         A2SDatagram(Element* data, size_t len) : Data(data, len), next(std::begin(Data))
+        {
+        }
+
+        A2SDatagram(rallyhere::string& data) : Data(reinterpret_cast<uint8_t*>(data.data()), data.size()), next(std::begin(Data))
         {
         }
 
@@ -218,9 +237,27 @@ namespace rallyhere
             return *this;
         }
 
+        A2SDatagram& operator>>(a2s_simple_response& response)
+        {
+            *this >> response.header >> response.type;
+            return *this;
+        }
+
+        A2SDatagram& operator>>(a2s_challenge_response& response)
+        {
+            *this >> response.header >> response.type >> response.challenge;
+            return *this;
+        }
+
         size_t size() const
         {
             return next - std::begin(Data);
+        }
+
+        void seek(size_t pos)
+        {
+            next = std::begin(Data) + pos;
+            overflowed = next >= std::end(Data);
         }
 
         boost::span<uint8_t> Data;

--- a/src/complete/a2s_listener.hpp
+++ b/src/complete/a2s_listener.hpp
@@ -118,6 +118,8 @@ class a2s_listener : public std::enable_shared_from_this<a2s_listener>
 
     bool handle_info(size_t len)
     {
+        const auto A2S_CHALLENGE_FIELD_SIZE = 4;
+        static_assert (A2S_CHALLENGE_FIELD_SIZE == sizeof(int32_t), "A2S_CHALLENGE_FIELD_SIZE must be 4");
         if (len == sizeof(a2s_simple_response))
             return warn(boost::system::errc::invalid_argument, "payload too small");
         auto begin = m_Buffer.begin() + sizeof(a2s_simple_response);
@@ -142,7 +144,7 @@ class a2s_listener : public std::enable_shared_from_this<a2s_listener>
         {
             // Check that the challenge is valid
             A2SDatagram datagram(it, len - total_len);
-            if ((len - total_len) != 4)
+            if ((len - total_len) != A2S_CHALLENGE_FIELD_SIZE)
                 return warn(boost::system::errc::invalid_argument, "invalid challenge size");
             int32_t current_challenge;
             datagram >> current_challenge;

--- a/src/complete/a2s_listener.hpp
+++ b/src/complete/a2s_listener.hpp
@@ -43,8 +43,8 @@ class a2s_listener : public std::enable_shared_from_this<a2s_listener>
 {
     using udp = boost::asio::ip::udp; // from <boost/asio/ip/udp.hpp>
   public:
-    a2s_listener(boost::asio::any_io_executor ex, short port, logger logger) :
-        m_Socket(ex, udp::endpoint(udp::v4(), port)), m_Logger{ logger }
+    a2s_listener(boost::asio::any_io_executor ex, short port, logger logger, bool challenge ) :
+        m_Socket(ex, udp::endpoint(udp::v4(), port)), m_Logger{ logger }, m_ShouldChallenge{ challenge }
     {
     }
 
@@ -126,7 +126,7 @@ class a2s_listener : public std::enable_shared_from_this<a2s_listener>
             ++it;
         ++it;
         size_t total_len = it - m_Buffer.begin();
-        if (total_len == len)
+        if (m_ShouldChallenge && total_len == len)
         {
             // Send back this request with a challenge
             A2SDatagram datagram(m_Buffer);
@@ -136,34 +136,35 @@ class a2s_listener : public std::enable_shared_from_this<a2s_listener>
             datagram << m_ServerInfo.ResponseHeader << m_ServerInfo.Header << current_challenge;
             m_RecentChallenges.push_back(current_challenge);
             do_send(datagram.size());
+            return true;
         }
-        else
+        if (m_ShouldChallenge && total_len != len)
         {
-            // Check if successful challenge
-            {
-                A2SDatagram datagram(it, len - total_len);
-                if ((len - total_len) != 4)
-                    return warn(boost::system::errc::invalid_argument, "invalid challenge size");
-                int32_t current_challenge;
-                datagram >> current_challenge;
-                auto existing_challenge = std::find(m_RecentChallenges.begin(), m_RecentChallenges.end(), current_challenge);
-                if (existing_challenge == m_RecentChallenges.end())
-                    return warn(boost::system::errc::invalid_argument, "invalid challenge", current_challenge);
-                m_RecentChallenges.erase(existing_challenge);
-            }
-            // Send back A2S_INFO response
-            A2SDatagram datagram(m_Buffer);
-            m_ServerInfo.ResponseHeader = -1;
-            m_ServerInfo.Header = 'I';
-            m_ServerInfo.EDF = 0;
-            datagram << m_ServerInfo.ResponseHeader << m_ServerInfo.Header << m_ServerInfo.Protocol << m_ServerInfo.Name << m_ServerInfo.Map
-                     << m_ServerInfo.Folder << m_ServerInfo.GameName << m_ServerInfo.ID << m_ServerInfo.Players << m_ServerInfo.MaxPlayers
-                     << m_ServerInfo.Bots << m_ServerInfo.ServerType << m_ServerInfo.Environment << m_ServerInfo.Visibility << m_ServerInfo.VAC
-                     << m_ServerInfo.Version << m_ServerInfo.EDF;
-            if (datagram.overflowed)
-                return warn(boost::system::errc::invalid_argument, "data too large for single datagram");
-            do_send(datagram.size());
+            // Check that the challenge is valid
+            A2SDatagram datagram(it, len - total_len);
+            if ((len - total_len) != 4)
+                return warn(boost::system::errc::invalid_argument, "invalid challenge size");
+            int32_t current_challenge;
+            datagram >> current_challenge;
+            auto existing_challenge = std::find(m_RecentChallenges.begin(), m_RecentChallenges.end(), current_challenge);
+            if (existing_challenge == m_RecentChallenges.end())
+                return warn(boost::system::errc::invalid_argument, "invalid challenge", current_challenge);
+            m_RecentChallenges.erase(existing_challenge);
         }
+        if (!m_ShouldChallenge && total_len != len)
+            return warn(boost::system::errc::invalid_argument, "challenges not supported");
+        // Send back A2S_INFO response
+        A2SDatagram datagram(m_Buffer);
+        m_ServerInfo.ResponseHeader = -1;
+        m_ServerInfo.Header = 'I';
+        m_ServerInfo.EDF = 0;
+        datagram << m_ServerInfo.ResponseHeader << m_ServerInfo.Header << m_ServerInfo.Protocol << m_ServerInfo.Name << m_ServerInfo.Map
+                 << m_ServerInfo.Folder << m_ServerInfo.GameName << m_ServerInfo.ID << m_ServerInfo.Players << m_ServerInfo.MaxPlayers
+                 << m_ServerInfo.Bots << m_ServerInfo.ServerType << m_ServerInfo.Environment << m_ServerInfo.Visibility << m_ServerInfo.VAC
+                 << m_ServerInfo.Version << m_ServerInfo.EDF;
+        if (datagram.overflowed)
+            return warn(boost::system::errc::invalid_argument, "data too large for single datagram");
+        do_send(datagram.size());
         return true;
     }
 
@@ -325,6 +326,7 @@ class a2s_listener : public std::enable_shared_from_this<a2s_listener>
     std::default_random_engine m_RandomEngine{ m_RandomDevice() };
     std::uniform_int_distribution<int32_t> m_ChallengeDistribution{1};
     rallyhere::vector<int32_t> m_Challenges{};
+    bool m_ShouldChallenge{true};
 };
 
 } // namespace rallyhere

--- a/src/complete/a2s_listener.hpp
+++ b/src/complete/a2s_listener.hpp
@@ -30,10 +30,14 @@ limitations under the License.
 #include "sdk_logger.h"
 #include "stats.hpp"
 #include <random>
+#include "boost/circular_buffer.hpp"
 
 
 namespace rallyhere
 {
+
+template<class T>
+using circular_buffer = boost::circular_buffer<T, i3d::one::StandardAllocator<T>>;
 
 class a2s_listener : public std::enable_shared_from_this<a2s_listener>
 {
@@ -315,7 +319,7 @@ class a2s_listener : public std::enable_shared_from_this<a2s_listener>
     bool m_Cancelled{ false };
     boost::system::error_code m_Error{};
     server_info m_ServerInfo;
-    rallyhere::vector<int32_t> m_RecentChallenges;
+    circular_buffer<int32_t> m_RecentChallenges{20};
     logger m_Logger{};
     std::random_device m_RandomDevice{};
     std::default_random_engine m_RandomEngine{ m_RandomDevice() };

--- a/src/complete/sdk.cpp
+++ b/src/complete/sdk.cpp
@@ -398,6 +398,12 @@ void GameInstanceAdapter::SetupA2S()
             }
             continue;
         }
+        if (ParseArgument("A2Schallenge=", arg, tmp))
+        {
+            if (tmp[0] == 'f' || tmp[0] == 'F' || tmp[0] == '0' || tmp[0] == 'n' || tmp[0] == 'N')
+                m_A2SChallenge = false;
+            continue;
+        }
     }
 
     m_StatsBase.server_type = 'd';

--- a/src/complete/sdk.h
+++ b/src/complete/sdk.h
@@ -543,6 +543,7 @@ class GameInstanceAdapter
     /// @{
     short m_A2SQueryPort{0};
     std::shared_ptr<rallyhere::a2s_listener> m_A2SListener{};
+    bool m_A2SChallenge{true};
     /// @}
 
     rallyhere::string m_UserAgent;

--- a/src/complete/sdk_multiplay.cpp
+++ b/src/complete/sdk_multiplay.cpp
@@ -145,7 +145,7 @@ void GameInstanceAdapter::ReadyMultiplay(base_callback_function_t callback, void
     m_MultiplayServerFileWatcher->run();
     // Setup A2S
     auto a2s_alloc = i3d::one::StandardAllocator<a2s_listener>{};
-    m_A2SListener = std::allocate_shared<a2s_listener>(a2s_alloc, net::make_strand(m_IoContext), m_A2SQueryPort, log());
+    m_A2SListener = std::allocate_shared<a2s_listener>(a2s_alloc, net::make_strand(m_IoContext), m_A2SQueryPort, log(), m_A2SChallenge);
     if (m_A2SListener->fail())
     {
         log().log(RH_LOG_LEVEL_ERROR, "Failed to start A2S listener");

--- a/src/complete/sdk_sic.cpp
+++ b/src/complete/sdk_sic.cpp
@@ -1023,7 +1023,7 @@ void GameInstanceAdapter::ReadySIC(base_callback_function_t callback, void* user
         log().log(RH_LOG_LEVEL_INFO, "Setting up A2S for SIC");
         // Setup A2S
         auto a2s_alloc = i3d::one::StandardAllocator<a2s_listener>{};
-        m_A2SListener = std::allocate_shared<a2s_listener>(a2s_alloc, net::make_strand(m_IoContext), m_A2SQueryPort, log());
+        m_A2SListener = std::allocate_shared<a2s_listener>(a2s_alloc, net::make_strand(m_IoContext), m_A2SQueryPort, log(), m_A2SChallenge);
         if (m_A2SListener->fail())
         {
             log().log(RH_LOG_LEVEL_ERROR, "Failed to start A2S listener");

--- a/test/c_interface/shared_a2s.cpp
+++ b/test/c_interface/shared_a2s.cpp
@@ -107,7 +107,7 @@ static rallyhere::server_info get_stats_impl(lest::env& lest_env, RallyHereGameI
     using namespace std::chrono_literals;
     wait_for(
         lest_env,
-        12s,
+        DEFAULT_WAIT,
         [&handler] {
             return handler.received;
         },

--- a/test/c_interface/shared_a2s.cpp
+++ b/test/c_interface/shared_a2s.cpp
@@ -25,6 +25,7 @@ limitations under the License.
 #include "a2s.hpp"
 #include "shared_test_data.h"
 #include "shared_a2s.h"
+#include "configuration.h"
 
 using boost::asio::ip::udp;
 
@@ -150,7 +151,7 @@ static rallyhere::server_info get_stats_impl(lest::env& lest_env, RallyHereGameI
                 io_context.restart();
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10 + 2));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
     }
 
@@ -197,7 +198,7 @@ void get_stats_fail_challenge(lest::env& lest_env, RallyHereGameInstanceAdapterP
             io_context.restart();
         auto ongoing = std::chrono::steady_clock::now();
         auto elapsed = ongoing - start;
-        EXPECT(elapsed < std::chrono::seconds(10 + 2));
+        EXPECT(elapsed < DEFAULT_WAIT);
     }
 
     if (handler.challenge.challenge != 0)
@@ -222,7 +223,7 @@ void get_stats_fail_challenge(lest::env& lest_env, RallyHereGameInstanceAdapterP
                 io_context.restart();
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            if (elapsed > std::chrono::seconds(2))
+            if (elapsed > SHORT_WAIT)
             {
                 return;
             }
@@ -264,7 +265,7 @@ size_t get_stats_pending_challenges(lest::env& lest_env, RallyHereGameInstanceAd
                 io_context.restart();
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10 + 2));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
 
         EXPECT(handler.is_challenge == true);
@@ -301,7 +302,7 @@ size_t get_stats_pending_challenges(lest::env& lest_env, RallyHereGameInstanceAd
                 io_context.restart();
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            if (elapsed > std::chrono::seconds(2))
+            if (elapsed > SHORT_WAIT)
             {
                 break;
             }

--- a/test/c_interface/shared_a2s.cpp
+++ b/test/c_interface/shared_a2s.cpp
@@ -70,7 +70,7 @@ struct a2s_response_handler
     }
 };
 
-rallyhere::server_info get_stats(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data)
+static rallyhere::server_info get_stats_impl(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data, bool should_challenge)
 {
     boost::asio::io_context io_context;
 
@@ -102,6 +102,15 @@ rallyhere::server_info get_stats(lest::env& lest_env, RallyHereGameInstanceAdapt
         EXPECT(elapsed < std::chrono::seconds(10 + 2));
     }
 
+    if (should_challenge)
+    {
+        EXPECT(handler.is_challenge == true);
+    }
+    else
+    {
+        EXPECT(handler.is_challenge == false);
+    }
+
     if (handler.is_challenge)
     {
         rallyhere::string source_buf{ "\xff\xff\xff\xff\x54Source Engine Query\0\xff\xff\xff\xff", 25 + 4 };
@@ -130,6 +139,16 @@ rallyhere::server_info get_stats(lest::env& lest_env, RallyHereGameInstanceAdapt
 
     validate_server_info(lest_env, handler.info);
     return handler.info;
+}
+
+rallyhere::server_info get_stats(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data)
+{
+    return get_stats_impl(lest_env, adapter, data, true);
+}
+
+rallyhere::server_info get_stats_no_challenge(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data)
+{
+    return get_stats_impl(lest_env, adapter, data, false);
 }
 
 void get_stats_fail_challenge(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data)

--- a/test/c_interface/shared_a2s.cpp
+++ b/test/c_interface/shared_a2s.cpp
@@ -36,6 +36,36 @@ void validate_server_info(lest::env& lest_env, const rallyhere::server_info& inf
     EXPECT(info.EDF == 0);
 }
 
+struct a2s_response_handler
+{
+    lest::env& lest_env;
+    boost::array<uint8_t, rallyhere::A2S_MAX_DATA_SIZE + rallyhere::UDP_HEADER_SIZE> recv_buf{};
+    bool received{ false };
+    rallyhere::a2s_simple_response response{};
+    rallyhere::a2s_challenge_response challenge{};
+    rallyhere::server_info info{};
+
+    void operator()(const boost::system::error_code& ec, size_t len)
+    {
+        received = true;
+        rallyhere::A2SDatagram datagram{ recv_buf.data(), len };
+        datagram >> response;
+        datagram.seek(0);
+        if (response.type == rallyhere::a2s_response_type::challenge)
+        {
+            datagram >> challenge;
+        }
+        else if (response.type == rallyhere::a2s_response_type::info)
+        {
+            datagram >> info;
+        }
+        else
+        {
+            EXPECT(response.type == rallyhere::a2s_response_type::info);
+        }
+    }
+};
+
 rallyhere::server_info get_stats(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data)
 {
     boost::asio::io_context io_context;
@@ -49,19 +79,12 @@ rallyhere::server_info get_stats(lest::env& lest_env, RallyHereGameInstanceAdapt
     std::string_view send_buf = { "\xff\xff\xff\xff\x54Source Engine Query\0", 25 };
     socket.send_to(boost::asio::buffer(send_buf), receiver_endpoint);
 
-    boost::array<uint8_t, rallyhere::A2S_MAX_DATA_SIZE + rallyhere::UDP_HEADER_SIZE> recv_buf;
+    a2s_response_handler handler{ lest_env };
     udp::endpoint sender_endpoint;
-    bool received{ false };
-    rallyhere::server_info info{};
-    socket.async_receive_from(
-        boost::asio::buffer(recv_buf), sender_endpoint, [&received, &recv_buf, &info](const boost::system::error_code& ec, size_t len) {
-            received = true;
-            rallyhere::A2SDatagram datagram{ recv_buf.data(), len };
-            datagram >> info;
-        });
+    socket.async_receive_from(boost::asio::buffer(handler.recv_buf), sender_endpoint, std::ref(handler));
 
     auto start = std::chrono::steady_clock::now();
-    while (!received)
+    while (!handler.received)
     {
         EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
         io_context.poll();
@@ -70,6 +93,27 @@ rallyhere::server_info get_stats(lest::env& lest_env, RallyHereGameInstanceAdapt
         EXPECT(elapsed < std::chrono::seconds(10 + 2));
     }
 
-    validate_server_info(lest_env, info);
-    return info;
+    if (handler.challenge.challenge != 0)
+    {
+        rallyhere::string send_buf = "\xff\xff\xff\xff\x54Source Engine Query\0\xff\xff\xff\xff";
+        rallyhere::A2SDatagram datagram{ send_buf };
+        datagram.seek(25);
+        datagram << handler.challenge.challenge;
+
+        udp::endpoint sender_endpoint;
+        socket.async_receive_from(boost::asio::buffer(handler.recv_buf), sender_endpoint, std::ref(handler));
+
+        start = std::chrono::steady_clock::now();
+        while (!handler.received)
+        {
+            EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
+            io_context.poll();
+            auto ongoing = std::chrono::steady_clock::now();
+            auto elapsed = ongoing - start;
+            EXPECT(elapsed < std::chrono::seconds(10 + 2));
+        }
+    }
+
+    validate_server_info(lest_env, handler.info);
+    return handler.info;
 }

--- a/test/c_interface/shared_a2s.cpp
+++ b/test/c_interface/shared_a2s.cpp
@@ -131,3 +131,66 @@ rallyhere::server_info get_stats(lest::env& lest_env, RallyHereGameInstanceAdapt
     validate_server_info(lest_env, handler.info);
     return handler.info;
 }
+
+void get_stats_fail_challenge(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data)
+{
+    boost::asio::io_context io_context;
+
+    udp::resolver resolver(io_context);
+    udp::endpoint receiver_endpoint = *resolver.resolve(udp::v4(), "localhost", "23891").begin();
+
+    udp::socket socket(io_context);
+    socket.open(udp::v4());
+
+    {
+        std::string_view send_buf = { "\xff\xff\xff\xff\x54Source Engine Query\0", 25 };
+        auto sent = socket.send_to(boost::asio::buffer(send_buf), receiver_endpoint);
+        EXPECT(sent == send_buf.size());
+    }
+
+    a2s_response_handler handler{ lest_env };
+    udp::endpoint sender_endpoint;
+    socket.async_receive_from(boost::asio::buffer(handler.recv_buf), sender_endpoint, std::ref(handler));
+
+    auto start = std::chrono::steady_clock::now();
+    while (!handler.received)
+    {
+        EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
+        io_context.poll();
+        if (io_context.stopped())
+            io_context.restart();
+        auto ongoing = std::chrono::steady_clock::now();
+        auto elapsed = ongoing - start;
+        EXPECT(elapsed < std::chrono::seconds(10 + 2));
+    }
+
+    if (handler.challenge.challenge != 0)
+    {
+        rallyhere::string source_buf{ "\xff\xff\xff\xff\x54Source Engine Query\0\xff\xff\xff\xff", 25 + 4 };
+        rallyhere::vector<uint8_t> challenge_buf{ source_buf.begin(), source_buf.end() };
+        rallyhere::A2SDatagram datagram{ challenge_buf };
+        datagram.seek(25);
+        datagram << handler.challenge.challenge + 1;
+        auto sent = socket.send_to(boost::asio::buffer(challenge_buf.data(), challenge_buf.size()), receiver_endpoint);
+        EXPECT(sent == challenge_buf.size());
+
+        handler.received = false;
+        socket.async_receive_from(boost::asio::buffer(handler.recv_buf), sender_endpoint, std::ref(handler));
+
+        start = std::chrono::steady_clock::now();
+        while (!handler.received)
+        {
+            EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
+            io_context.poll();
+            if (io_context.stopped())
+                io_context.restart();
+            auto ongoing = std::chrono::steady_clock::now();
+            auto elapsed = ongoing - start;
+            if (elapsed > std::chrono::seconds(2))
+            {
+                return;
+            }
+        }
+        EXPECT(handler.received == false);
+    }
+}

--- a/test/c_interface/shared_a2s.h
+++ b/test/c_interface/shared_a2s.h
@@ -23,5 +23,6 @@ limitations under the License.
 
 void validate_server_info(lest::env& lest_env, const rallyhere::server_info& info);
 rallyhere::server_info get_stats(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data);
+rallyhere::server_info get_stats_no_challenge(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data);
 void get_stats_fail_challenge(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data);
 size_t get_stats_pending_challenges(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data, int num_pending);

--- a/test/c_interface/shared_a2s.h
+++ b/test/c_interface/shared_a2s.h
@@ -24,3 +24,4 @@ limitations under the License.
 void validate_server_info(lest::env& lest_env, const rallyhere::server_info& info);
 rallyhere::server_info get_stats(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data);
 void get_stats_fail_challenge(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data);
+size_t get_stats_pending_challenges(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data, int num_pending);

--- a/test/c_interface/shared_a2s.h
+++ b/test/c_interface/shared_a2s.h
@@ -23,3 +23,4 @@ limitations under the License.
 
 void validate_server_info(lest::env& lest_env, const rallyhere::server_info& info);
 rallyhere::server_info get_stats(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data);
+void get_stats_fail_challenge(lest::env& lest_env, RallyHereGameInstanceAdapterPtr adapter, TestCCodeData& data);

--- a/test/c_interface/shared_definitions.hpp
+++ b/test/c_interface/shared_definitions.hpp
@@ -71,7 +71,7 @@ while (!data.connect_called) \
     EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK); \
     auto ongoing = std::chrono::steady_clock::now(); \
     auto elapsed = ongoing - start; \
-    EXPECT(elapsed < std::chrono::seconds(10)); \
+    EXPECT(elapsed < DEFAULT_WAIT); \
 } \
 EXPECT(data.connect_result == RH_STATUS_OK);
 
@@ -84,7 +84,7 @@ while (!data.ready_called) \
     EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK); \
     auto ongoing = std::chrono::steady_clock::now(); \
     auto elapsed = ongoing - start; \
-    EXPECT(elapsed < std::chrono::seconds(10)); \
+    EXPECT(elapsed < DEFAULT_WAIT); \
 } \
 EXPECT(data.ready_result == RH_STATUS_OK);
 

--- a/test/c_interface/test_metrics.cpp
+++ b/test/c_interface/test_metrics.cpp
@@ -591,8 +591,8 @@ static const lest::test module[] = {
             .bots = 100,
             .server_type = 'd',
             .environment = 'l',
-            .visibility = '1',
-            .anticheat = '0',
+            .visibility = 1,
+            .anticheat = 0,
             .version = "0.0.1",
         };
         expected_instance_info["name"] = "the best test server";
@@ -639,8 +639,8 @@ static const lest::test module[] = {
             .bots = 100,
             .server_type = 'd',
             .environment = 'l',
-            .visibility = '1',
-            .anticheat = '0',
+            .visibility = 1,
+            .anticheat = 0,
             .version = "0.0.1",
         };
         expected_instance_info["name"] = "the best test server";
@@ -758,8 +758,8 @@ static const lest::test module[] = {
             .bots = 100,
             .server_type = 'd',
             .environment = 'l',
-            .visibility = '1',
-            .anticheat = '0',
+            .visibility = 1,
+            .anticheat = 0,
             .version = "0.0.1",
         };
         expected_instance_info["name"] = "the best test server";

--- a/test/c_interface/test_metrics.cpp
+++ b/test/c_interface/test_metrics.cpp
@@ -397,7 +397,7 @@ void get_raw_metrics(lest::env & lest_env, RallyHereGameInstanceAdapterPtr adapt
             }
         }
     };
-    session_ptr->run(url, std::move(request_pair.first), wrapper, log(), true, std::chrono::seconds(10));
+    session_ptr->run(url, std::move(request_pair.first), wrapper, log(), true, DEFAULT_WAIT);
 
     auto start = std::chrono::steady_clock::now();
     while (!metrics_ready)
@@ -408,7 +408,7 @@ void get_raw_metrics(lest::env & lest_env, RallyHereGameInstanceAdapterPtr adapt
         EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
         auto ongoing = std::chrono::steady_clock::now();
         auto elapsed = ongoing - start;
-        EXPECT(elapsed < std::chrono::seconds(10));
+        EXPECT(elapsed < DEFAULT_WAIT);
     }
 }
 
@@ -457,7 +457,7 @@ void get_instance_info_labels(lest::env & lest_env, RallyHereGameInstanceAdapter
             }
         }
     };
-    session_ptr->run(url, std::move(request_pair.first), wrapper, log(), true, std::chrono::seconds(10));
+    session_ptr->run(url, std::move(request_pair.first), wrapper, log(), true, DEFAULT_WAIT);
 
     auto start = std::chrono::steady_clock::now();
     while (!metrics_ready)
@@ -468,7 +468,7 @@ void get_instance_info_labels(lest::env & lest_env, RallyHereGameInstanceAdapter
         EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
         auto ongoing = std::chrono::steady_clock::now();
         auto elapsed = ongoing - start;
-        EXPECT(elapsed < std::chrono::seconds(10));
+        EXPECT(elapsed < DEFAULT_WAIT);
     }
 }
 
@@ -515,7 +515,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.set_labels_result == RH_STATUS_OK);
 
@@ -531,7 +531,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.set_labels_result == RH_STATUS_PROMETHEUS_ALREADY_STARTED);
 
@@ -555,7 +555,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.set_additional_info_result == RH_STATUS_OK);
 
@@ -678,7 +678,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.set_additional_info_result == RH_STATUS_OK);
 
@@ -797,7 +797,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.set_additional_info_result == RH_STATUS_OK);
 
@@ -821,7 +821,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10 + 2));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.allocated_called == true);
         EXPECT(data.allocated_result == RH_STATUS_OK);

--- a/test/c_interface/test_multiplay.cpp
+++ b/test/c_interface/test_multiplay.cpp
@@ -61,7 +61,7 @@ void tick_adapter(lest::env &lest_env, RallyHereGameInstanceAdapterPtr adapter, 
     EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
     auto ongoing = std::chrono::steady_clock::now();
     auto elapsed = ongoing - start;
-    EXPECT(elapsed < std::chrono::seconds(10 + 2));
+    EXPECT(elapsed < DEFAULT_WAIT);
 }
 
 //@formatter:off
@@ -89,7 +89,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.connect_result == RH_STATUS_OK);
 
@@ -126,7 +126,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.connect_result == RH_STATUS_OK);
 
@@ -176,7 +176,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.connect_result == RH_STATUS_OK);
 
@@ -188,7 +188,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.reserve_result == RH_STATUS_OK);
 
@@ -206,7 +206,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.allocate_result == RH_STATUS_OK);
 
@@ -217,7 +217,7 @@ static const lest::test module[] = {
             EXPECT(data.ready_called == false);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            if (elapsed < std::chrono::seconds(10))
+            if (elapsed < DEFAULT_WAIT)
             {
                 break;
             }
@@ -246,7 +246,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.connect_result == RH_STATUS_OK);
 
@@ -261,7 +261,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.reserve_result == RH_STATUS_OK);
 
@@ -312,7 +312,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.connect_result == RH_STATUS_OK);
 
@@ -331,7 +331,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.ready_result == RH_STATUS_OK);
 
@@ -353,7 +353,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10 + 2));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.allocated_called == true);
         EXPECT(data.allocated_result == RH_STATUS_OK);

--- a/test/c_interface/test_multiplay.h
+++ b/test/c_interface/test_multiplay.h
@@ -83,6 +83,16 @@ struct TestArguments
 };
 
 template<typename T>
+struct TestArgumentsNoChallenge : public TestArguments<T>
+{
+    TestArgumentsNoChallenge() : TestArguments<T>()
+    {
+        this->arguments.push_back("A2SChallenge=0");
+        this->arguments_str = join(this->arguments, " ");
+    }
+};
+
+template<typename T>
 struct ServerJson
 {
     rallyhere::string path;

--- a/test/c_interface/test_multiplay_a2s.cpp
+++ b/test/c_interface/test_multiplay_a2s.cpp
@@ -42,8 +42,8 @@ RallyHereStatsBase get_stats_base()
         .bots = 100,
         .server_type = 'd',
         .environment = 'l',
-        .visibility = '1',
-        .anticheat = '0',
+        .visibility = 1,
+        .anticheat = 0,
         .version = "0.0.1",
     };
 }

--- a/test/c_interface/test_multiplay_a2s.cpp
+++ b/test/c_interface/test_multiplay_a2s.cpp
@@ -276,6 +276,19 @@ static const lest::test module[] = {
         auto completed = get_stats_pending_challenges(lest_env, adapter, data, 21);
         EXPECT(completed == 20);
     },
+    CASE("A2S properly deletes old challenges")
+    {
+        RallyHereGameInstanceAdapterPtr adapter{nullptr};
+        TestCCodeData data{};
+        get_multiplay_ready(lest_env, adapter, data);
+        BOOST_SCOPE_EXIT_ALL(adapter) {
+            rallyhere_destroy_game_instance_adapter(adapter);
+        };
+        auto completed = get_stats_pending_challenges(lest_env, adapter, data, 20);
+        EXPECT(completed == 20);
+        completed = get_stats_pending_challenges(lest_env, adapter, data, 20);
+        EXPECT(completed == 20);
+    },
 };
 //@formatter:on
 // clang-format off

--- a/test/c_interface/test_multiplay_a2s.cpp
+++ b/test/c_interface/test_multiplay_a2s.cpp
@@ -254,6 +254,28 @@ static const lest::test module[] = {
         };
         get_stats_fail_challenge(lest_env, adapter, data);
     },
+    CASE("A2S allows up to 20 pending challenges")
+    {
+        RallyHereGameInstanceAdapterPtr adapter{nullptr};
+        TestCCodeData data{};
+        get_multiplay_ready(lest_env, adapter, data);
+        BOOST_SCOPE_EXIT_ALL(adapter) {
+            rallyhere_destroy_game_instance_adapter(adapter);
+        };
+        auto completed = get_stats_pending_challenges(lest_env, adapter, data, 20);
+        EXPECT(completed == 20);
+    },
+    CASE("A2S fails the 21st pending challenge")
+    {
+        RallyHereGameInstanceAdapterPtr adapter{nullptr};
+        TestCCodeData data{};
+        get_multiplay_ready(lest_env, adapter, data);
+        BOOST_SCOPE_EXIT_ALL(adapter) {
+            rallyhere_destroy_game_instance_adapter(adapter);
+        };
+        auto completed = get_stats_pending_challenges(lest_env, adapter, data, 21);
+        EXPECT(completed == 20);
+    },
 };
 //@formatter:on
 // clang-format off

--- a/test/c_interface/test_multiplay_a2s.cpp
+++ b/test/c_interface/test_multiplay_a2s.cpp
@@ -82,7 +82,7 @@ void get_multiplay_ready(lest::env& lest_env, RallyHereGameInstanceAdapterPtr& a
         EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
         auto ongoing = std::chrono::steady_clock::now();
         auto elapsed = ongoing - start;
-        EXPECT(elapsed < std::chrono::seconds(10));
+        EXPECT(elapsed < DEFAULT_WAIT);
     }
     EXPECT(data.connect_result == RH_STATUS_OK);
 
@@ -109,7 +109,7 @@ void get_multiplay_ready(lest::env& lest_env, RallyHereGameInstanceAdapterPtr& a
         EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
         auto ongoing = std::chrono::steady_clock::now();
         auto elapsed = ongoing - start;
-        EXPECT(elapsed < std::chrono::seconds(10));
+        EXPECT(elapsed < DEFAULT_WAIT);
     }
     EXPECT(data.ready_result == RH_STATUS_OK);
 
@@ -122,7 +122,7 @@ void get_multiplay_ready(lest::env& lest_env, RallyHereGameInstanceAdapterPtr& a
         EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
         auto ongoing = std::chrono::steady_clock::now();
         auto elapsed = ongoing - start;
-        EXPECT(elapsed < std::chrono::seconds(10 + 2));
+        EXPECT(elapsed < DEFAULT_WAIT);
     }
     EXPECT(data.set_base_stats_called == true);
     EXPECT(data.set_base_stats_result == RH_STATUS_OK);
@@ -149,7 +149,7 @@ void write_new_stats(lest::env& lest_env,
         EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
         auto ongoing = std::chrono::steady_clock::now();
         auto elapsed = ongoing - start;
-        EXPECT(elapsed < std::chrono::seconds(10 + 2));
+        EXPECT(elapsed < DEFAULT_WAIT);
     }
     EXPECT(data.set_base_stats_called == true);
     EXPECT(data.set_base_stats_result == RH_STATUS_OK);

--- a/test/c_interface/test_multiplay_a2s.cpp
+++ b/test/c_interface/test_multiplay_a2s.cpp
@@ -243,7 +243,17 @@ static const lest::test module[] = {
         make_bad_request(lest_env, adapter, data);
         rallyhere::server_info info = get_stats(lest_env, adapter, data);
         compare(lest_env, get_stats_base(), info);
-    }
+    },
+    CASE("A2S fails to return when challenge fails")
+    {
+        RallyHereGameInstanceAdapterPtr adapter{nullptr};
+        TestCCodeData data{};
+        get_multiplay_ready(lest_env, adapter, data);
+        BOOST_SCOPE_EXIT_ALL(adapter) {
+            rallyhere_destroy_game_instance_adapter(adapter);
+        };
+        get_stats_fail_challenge(lest_env, adapter, data);
+    },
 };
 //@formatter:on
 // clang-format off

--- a/test/c_interface/test_sic.cpp
+++ b/test/c_interface/test_sic.cpp
@@ -132,7 +132,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.connect_result == RH_STATUS_OK);
 
@@ -144,7 +144,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.reserve_result == RH_STATUS_OK);
 
@@ -162,7 +162,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.allocate_result == RH_STATUS_OK);
 
@@ -173,7 +173,7 @@ static const lest::test module[] = {
             EXPECT(data.ready_called == false);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            if (elapsed < std::chrono::seconds(10))
+            if (elapsed < DEFAULT_WAIT)
             {
                 break;
             }
@@ -203,7 +203,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.connect_result == RH_STATUS_OK);
 
@@ -218,7 +218,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.reserve_result == RH_STATUS_OK);
 
@@ -231,7 +231,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10 + 2));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.ready_result == RH_STATUS_OK);
         EXPECT(data.ready_called == true);
@@ -258,7 +258,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.connect_result == RH_STATUS_OK);
 
@@ -290,7 +290,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.set_labels_result == RH_STATUS_OK);
 
@@ -304,7 +304,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.ready_result == RH_STATUS_OK);
 
@@ -319,7 +319,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.set_labels_result == RH_STATUS_PROMETHEUS_ALREADY_STARTED);
 
@@ -338,7 +338,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.set_additional_info_result == RH_STATUS_OK);
 
@@ -351,7 +351,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10 + 2));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.allocated_called == true);
         EXPECT(data.allocated_result == RH_STATUS_OK);
@@ -382,7 +382,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.connect_result == RH_STATUS_OK);
 
@@ -396,7 +396,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.ready_result == RH_STATUS_OK);
 
@@ -412,7 +412,7 @@ static const lest::test module[] = {
             EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10 + 2));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(data.allocated_called == true);
         EXPECT(data.allocated_result == RH_STATUS_OK);

--- a/test/c_interface/test_sic.h
+++ b/test/c_interface/test_sic.h
@@ -88,5 +88,15 @@ namespace sic
             return arguments_str.size();
         }
     };
+
+    template<typename T>
+    struct TestArgumentsNoChallenge : public TestArguments<T>
+    {
+        TestArgumentsNoChallenge()
+        {
+            this->arguments.push_back("A2SChallenge=0");
+            this->arguments_str = join(this->arguments, " ");
+        }
+    };
 } // namespace sic
 } // namespace test

--- a/test/c_interface/test_sic_a2s.cpp
+++ b/test/c_interface/test_sic_a2s.cpp
@@ -308,4 +308,4 @@ static const lest::test module[] = {
 
 extern lest::tests& specification();
 
-//MODULE( specification(), module );
+MODULE( specification(), module );

--- a/test/c_interface/test_sic_a2s.cpp
+++ b/test/c_interface/test_sic_a2s.cpp
@@ -82,7 +82,7 @@ void get_ready(lest::env& lest_env, RallyHereGameInstanceAdapterPtr& adapter, Te
         EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
         auto ongoing = std::chrono::steady_clock::now();
         auto elapsed = ongoing - start;
-        EXPECT(elapsed < std::chrono::seconds(10));
+        EXPECT(elapsed < DEFAULT_WAIT);
     }
     EXPECT(data.connect_result == RH_STATUS_OK);
 
@@ -103,7 +103,7 @@ void get_ready(lest::env& lest_env, RallyHereGameInstanceAdapterPtr& adapter, Te
         EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
         auto ongoing = std::chrono::steady_clock::now();
         auto elapsed = ongoing - start;
-        EXPECT(elapsed < std::chrono::seconds(10));
+        EXPECT(elapsed < DEFAULT_WAIT);
     }
     EXPECT(data.ready_result == RH_STATUS_OK);
 
@@ -116,7 +116,7 @@ void get_ready(lest::env& lest_env, RallyHereGameInstanceAdapterPtr& adapter, Te
         EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
         auto ongoing = std::chrono::steady_clock::now();
         auto elapsed = ongoing - start;
-        EXPECT(elapsed < std::chrono::seconds(10 + 2));
+        EXPECT(elapsed < DEFAULT_WAIT);
     }
     EXPECT(data.set_base_stats_called == true);
     EXPECT(data.set_base_stats_result == RH_STATUS_OK);
@@ -143,7 +143,7 @@ static void write_new_stats(lest::env& lest_env,
         EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
         auto ongoing = std::chrono::steady_clock::now();
         auto elapsed = ongoing - start;
-        EXPECT(elapsed < std::chrono::seconds(10 + 2));
+        EXPECT(elapsed < DEFAULT_WAIT);
     }
     EXPECT(data.set_base_stats_called == true);
     EXPECT(data.set_base_stats_result == RH_STATUS_OK);

--- a/test/c_interface/test_sic_a2s.cpp
+++ b/test/c_interface/test_sic_a2s.cpp
@@ -248,6 +248,28 @@ static const lest::test module[] = {
         };
         get_stats_fail_challenge(lest_env, adapter, data);
     },
+    CASE("A2S allows up to 20 pending challenges")
+    {
+        RallyHereGameInstanceAdapterPtr adapter{nullptr};
+        TestCCodeData data{};
+        get_ready(lest_env, adapter, data);
+        BOOST_SCOPE_EXIT_ALL(adapter) {
+            rallyhere_destroy_game_instance_adapter(adapter);
+        };
+        auto completed = get_stats_pending_challenges(lest_env, adapter, data, 20);
+        EXPECT(completed == 20);
+    },
+    CASE("A2S fails the 21st pending challenge")
+    {
+        RallyHereGameInstanceAdapterPtr adapter{nullptr};
+        TestCCodeData data{};
+        get_ready(lest_env, adapter, data);
+        BOOST_SCOPE_EXIT_ALL(adapter) {
+            rallyhere_destroy_game_instance_adapter(adapter);
+        };
+        auto completed = get_stats_pending_challenges(lest_env, adapter, data, 21);
+        EXPECT(completed == 20);
+    },
 };
 //@formatter:on
 // clang-format off

--- a/test/c_interface/test_sic_a2s.cpp
+++ b/test/c_interface/test_sic_a2s.cpp
@@ -237,11 +237,21 @@ static const lest::test module[] = {
         make_bad_request(lest_env, adapter, data);
         rallyhere::server_info info = get_stats(lest_env, adapter, data);
         compare(lest_env, get_stats_base(), info);
-    }
+    },
+    CASE("A2S fails to return when challenge fails")
+    {
+        RallyHereGameInstanceAdapterPtr adapter{nullptr};
+        TestCCodeData data{};
+        get_ready(lest_env, adapter, data);
+        BOOST_SCOPE_EXIT_ALL(adapter) {
+            rallyhere_destroy_game_instance_adapter(adapter);
+        };
+        get_stats_fail_challenge(lest_env, adapter, data);
+    },
 };
 //@formatter:on
 // clang-format off
 
 extern lest::tests& specification();
 
-MODULE( specification(), module );
+//MODULE( specification(), module );

--- a/test/c_interface/test_sic_a2s.cpp
+++ b/test/c_interface/test_sic_a2s.cpp
@@ -171,36 +171,7 @@ static const lest::test module[] = {
             rallyhere_destroy_game_instance_adapter(adapter);
         };
 
-        boost::asio::io_context io_context;
-
-        udp::resolver resolver(io_context);
-        udp::endpoint receiver_endpoint = *resolver.resolve(udp::v4(), "localhost", "23891").begin();
-
-        udp::socket socket(io_context);
-        socket.open(udp::v4());
-
-        std::string_view send_buf = { "\xff\xff\xff\xff\x54Source Engine Query\0", 25 };
-        socket.send_to(boost::asio::buffer(send_buf), receiver_endpoint);
-
-        boost::array<uint8_t, 128> recv_buf;
-        udp::endpoint sender_endpoint;
-        bool received{false};
-        rallyhere::server_info info{};
-        socket.async_receive_from(boost::asio::buffer(recv_buf), sender_endpoint, [&received, &recv_buf, &info](const boost::system::error_code& ec, size_t len) {
-            received = true;
-            rallyhere::A2SDatagram datagram{recv_buf.data(), len};
-            datagram >> info;
-        });
-
-        auto start = std::chrono::steady_clock::now();
-        while (!received)
-        {
-            EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK);
-            io_context.poll();
-            auto ongoing = std::chrono::steady_clock::now();
-            auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10 + 2));
-        }
+        rallyhere::server_info info = get_stats(lest_env, adapter, data);
         compare(lest_env, get_stats_base(), info);
     },
     CASE("A2S updates after ready")

--- a/test/c_interface/test_sic_a2s.cpp
+++ b/test/c_interface/test_sic_a2s.cpp
@@ -270,6 +270,19 @@ static const lest::test module[] = {
         auto completed = get_stats_pending_challenges(lest_env, adapter, data, 21);
         EXPECT(completed == 20);
     },
+    CASE("A2S properly deletes old challenges")
+    {
+        RallyHereGameInstanceAdapterPtr adapter{nullptr};
+        TestCCodeData data{};
+        get_ready(lest_env, adapter, data);
+        BOOST_SCOPE_EXIT_ALL(adapter) {
+            rallyhere_destroy_game_instance_adapter(adapter);
+        };
+        auto completed = get_stats_pending_challenges(lest_env, adapter, data, 20);
+        EXPECT(completed == 20);
+        completed = get_stats_pending_challenges(lest_env, adapter, data, 20);
+        EXPECT(completed == 20);
+    },
 };
 //@formatter:on
 // clang-format off

--- a/test/c_interface/test_sic_a2s.cpp
+++ b/test/c_interface/test_sic_a2s.cpp
@@ -42,8 +42,8 @@ static RallyHereStatsBase get_stats_base()
         .bots = 100,
         .server_type = 'd',
         .environment = 'l',
-        .visibility = '1',
-        .anticheat = '0',
+        .visibility = 1,
+        .anticheat = 0,
         .version = "0.0.1",
     };
 }

--- a/test/complete/shared_definitions.hpp
+++ b/test/complete/shared_definitions.hpp
@@ -70,7 +70,7 @@ while (!data.connect_called) \
     EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK); \
     auto ongoing = std::chrono::steady_clock::now(); \
     auto elapsed = ongoing - start; \
-    EXPECT(elapsed < std::chrono::seconds(10)); \
+    EXPECT(elapsed < DEFAULT_WAIT); \
 } \
 EXPECT(data.connect_result == RH_STATUS_OK);
 
@@ -83,7 +83,7 @@ while (!data.ready_called) \
     EXPECT(rallyhere_tick(adapter) == RH_STATUS_OK); \
     auto ongoing = std::chrono::steady_clock::now(); \
     auto elapsed = ongoing - start; \
-    EXPECT(elapsed < std::chrono::seconds(10)); \
+    EXPECT(elapsed < DEFAULT_WAIT); \
 } \
 EXPECT(data.ready_result == RH_STATUS_OK);
 

--- a/test/complete/test_sic.cpp
+++ b/test/complete/test_sic.cpp
@@ -133,7 +133,7 @@ static const lest::test module[] = {
             EXPECT(gia->Tick().ok() == true);
             auto ongoing = std::chrono::steady_clock::now();
             auto elapsed = ongoing - start;
-            EXPECT(elapsed < std::chrono::seconds(10));
+            EXPECT(elapsed < DEFAULT_WAIT);
         }
         EXPECT(connect_result.code() == RH_STATUS_OK);
         EXPECT(connect_result.ok() == true);

--- a/test/shared/configuration.h
+++ b/test/shared/configuration.h
@@ -34,3 +34,6 @@ const char* get_rally_here_url_arg();
 std::string get_credentials_file_path();
 const char* get_credentials_file_path_arg();
 const char* get_rh_credentials_as_arg();
+
+constexpr auto DEFAULT_WAIT = std::chrono::seconds(12);
+constexpr auto SHORT_WAIT = std::chrono::seconds(2);


### PR DESCRIPTION
- Challenge requests and responses
- Add a flag to disable challenges in case something doesn’t support them
- Make sure the challenge requests can’t be use to crash the instance through overallocation. This will result in them being able to deny service to the a2s port, but that’s better than taking down the whole instance
- Properly set visibility and anticheat to bytes instead of characters