### PR TITLE
Topic/fix append additional info labels

### DIFF
--- a/src/complete/sdk_sic.cpp
+++ b/src/complete/sdk_sic.cpp
@@ -887,14 +887,14 @@ void GameInstanceAdapter::SetupSIC()
         {
             rallyhere::vector<rallyhere::string> kv;
             boost::split(kv, label, boost::is_any_of(":"), boost::token_compress_on);
-            m_AdditionalInfoLabels.Set(kv[0].c_str(), kv[1]);
+            m_InternalAdditionalInfoLabels.Set(kv[0].c_str(), kv[1]);
         }
     }
     for (auto&& label : m_ExtraAdditionalInfoLabels)
     {
         rallyhere::vector<rallyhere::string> kv;
         boost::split(kv, label, boost::is_any_of(":"), boost::token_compress_on);
-        m_AdditionalInfoLabels.Set(kv[0].c_str(), kv[1]);
+        m_InternalAdditionalInfoLabels.Set(kv[0].c_str(), kv[1]);
     }
 
     rallyhere::string upperedState = m_LastPolledState;

--- a/test/c_interface/test_metrics.cpp
+++ b/test/c_interface/test_metrics.cpp
@@ -1101,6 +1101,35 @@ static const lest::test module[] = {
             EXPECT(labels_map.find(p.first) != labels_map.end());
             EXPECT(labels_map[p.first] == p.second);
         }
+    },
+    CASE("Test that additional info labels works")
+    {
+        auto arguments_source = demo_get_default_arguments<rallyhere::string>();
+        auto arguments = join(arguments_source, " ");
+        RallyHereGameInstanceAdapterPtr adapter;
+        rallyhere_global_init();
+        std::map<std::string, std::string> expected_instance_info;
+        expected_instance_info["addinfo"] = "nothanks";
+        auto result = rallyhere_create_game_instance_adaptern(&adapter, arguments.c_str(), arguments.size());
+        EXPECT(rallyhere_is_error(result) == false);
+        TestCCodeData data{};
+        BOOST_SCOPE_EXIT_ALL(adapter) {
+                                          rallyhere_destroy_game_instance_adapter(adapter);
+                                      };
+        data.adapter = adapter;
+
+        ADAPTER_CONNECT;
+        ADAPTER_READY;
+        ADAPTER_HEALTHY;
+        ADAPTER_TICK;
+
+        std::map<std::string, std::string> labels_map;
+        get_instance_info_labels(lest_env, adapter, labels_map);
+        for (auto&& p : expected_instance_info)
+        {
+            EXPECT(labels_map.find(p.first) != labels_map.end());
+            EXPECT(labels_map[p.first] == p.second);
+        }
     }
 };
 //@formatter:on

--- a/test/c_interface/test_metrics.cpp
+++ b/test/c_interface/test_metrics.cpp
@@ -1114,8 +1114,8 @@ static const lest::test module[] = {
         EXPECT(rallyhere_is_error(result) == false);
         TestCCodeData data{};
         BOOST_SCOPE_EXIT_ALL(adapter) {
-                                          rallyhere_destroy_game_instance_adapter(adapter);
-                                      };
+            rallyhere_destroy_game_instance_adapter(adapter);
+        };
         data.adapter = adapter;
 
         ADAPTER_CONNECT;
@@ -1124,6 +1124,56 @@ static const lest::test module[] = {
         ADAPTER_TICK;
 
         std::map<std::string, std::string> labels_map;
+        get_instance_info_labels(lest_env, adapter, labels_map);
+        for (auto&& p : expected_instance_info)
+        {
+            EXPECT(labels_map.find(p.first) != labels_map.end());
+            EXPECT(labels_map[p.first] == p.second);
+        }
+    },
+    CASE("Test that additional info labels stay after client sets info")
+    {
+        auto arguments_source = demo_get_default_arguments<rallyhere::string>();
+        auto arguments = join(arguments_source, " ");
+        RallyHereGameInstanceAdapterPtr adapter;
+        rallyhere_global_init();
+        std::map<std::string, std::string> expected_instance_info;
+        expected_instance_info["addinfo"] = "nothanks";
+        auto result = rallyhere_create_game_instance_adaptern(&adapter, arguments.c_str(), arguments.size());
+        EXPECT(rallyhere_is_error(result) == false);
+        TestCCodeData data{};
+        BOOST_SCOPE_EXIT_ALL(adapter) {
+            rallyhere_destroy_game_instance_adapter(adapter);
+        };
+        data.adapter = adapter;
+
+        ADAPTER_CONNECT;
+        ADAPTER_READY;
+        ADAPTER_HEALTHY;
+        ADAPTER_TICK;
+
+        std::map<std::string, std::string> labels_map;
+        get_instance_info_labels(lest_env, adapter, labels_map);
+        for (auto&& p : expected_instance_info)
+        {
+            EXPECT(labels_map.find(p.first) != labels_map.end());
+            EXPECT(labels_map[p.first] == p.second);
+        }
+
+        RallyHereStringMapPtr additional_info;
+        EXPECT(rallyhere_string_map_create(&additional_info) == RH_STATUS_OK);
+        BOOST_SCOPE_EXIT_ALL(additional_info) {
+            rallyhere_string_map_destroy(additional_info);
+        };
+        EXPECT(rallyhere_string_map_set(additional_info, "lemapis", "yesplease") == RH_STATUS_OK);
+        expected_instance_info["lemapis"] = "yesplease";
+        EXPECT(rallyhere_string_map_set(additional_info, "game_mode", "favafave") == RH_STATUS_OK);
+        expected_instance_info["game_mode"] = "favafave";
+        rallyhere_set_additional_info(adapter, additional_info, on_set_additional_info_callback, &data);
+
+        ADAPTER_TICK;
+
+        labels_map.clear();
         get_instance_info_labels(lest_env, adapter, labels_map);
         for (auto&& p : expected_instance_info)
         {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "game-host-adapter",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "homepage": "https://github.com/RallyHereInteractive/game-host-adapter",
   "builtin-baseline": "c9140a3b500812ad3206317885860d9553b93f13",
   "dependencies": [


### PR DESCRIPTION
When a game client called `rallyhere_set_additional_info` it would wipe out the values set by operations. This properly sets those values on the internal additional info so these two things will be additive instead.