### PR TITLE
Improvements for AutoCreate and Reserve mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,7 @@ if (LEST_INCLUDE_DIRS)
             test/complete/test_sdk_helpers.cpp
             test/complete/test_base64.cpp
             test/complete/test_base64.h
+            test/complete/test_provider.cpp
     )
     add_executable(${PROJECT_NAME}_complete_test
             ${complete_test_sources}

--- a/include/game-host-adapter/c_api.h
+++ b/include/game-host-adapter/c_api.h
@@ -233,6 +233,16 @@ extern "C"
                                       void (*callback)(const RallyHereStatusCode& code, void* user_data),
                                       void* user_data);
 
+    /// @brief Get any configured public host and port information.
+    ///
+    /// There are situations where you want to use the Reserve flow, but would like to reuse the operational paramaters
+    /// provided to SIC by RallyHere operations. This allows you to get a string map with the public_host and
+    /// public_port that were provided to the game host. This is currently only valid in SIC mode.
+    ///
+    /// Caller is responsible for freeing the string map with rallyhere_string_map_destroy.
+    /// @public @memberof RallyHereGameInstanceAdapter
+    RH_EXPORT void rallyhere_get_public_host_and_port(RallyHereGameInstanceAdapterPtr adapter, RallyHereStringMapPtr* map);
+
     /// @brief Tell the game host to reserve this game instance rather than marking it ready.
     ///
     /// This will stop the game host from destroying this game instance based on any ready timeouts. This is to be used

--- a/src/complete/c_api.cpp
+++ b/src/complete/c_api.cpp
@@ -218,6 +218,17 @@ namespace
         a->Allocate(callback, user_data);
     }
 
+    void get_public_host_and_port(RallyHereGameInstanceAdapterPtr adapter, RallyHereStringMapPtr* map)
+    {
+        if (nullptr == adapter)
+            return;
+        if (nullptr == map)
+            return;
+        auto a = reinterpret_cast<rallyhere::GameInstanceAdapter*>(adapter);
+        auto m = a->GetPublicHostAndPort();
+        *map = reinterpret_cast<RallyHereStringMapPtr>(m);
+    }
+
     void reserve(RallyHereGameInstanceAdapterPtr adapter,
                  unsigned int timeout_seconds,
                  void (*reserve_callback)(const RallyHereStatusCode& code, void* user_data),
@@ -590,6 +601,11 @@ extern "C"
                             void* user_data)
     {
         rallyhere::allocate(adapter, callback, user_data);
+    }
+
+    void rallyhere_get_public_host_and_port(RallyHereGameInstanceAdapterPtr adapter, RallyHereStringMapPtr* map)
+    {
+        rallyhere::get_public_host_and_port(adapter, map);
     }
 
     void rallyhere_reserve(RallyHereGameInstanceAdapterPtr adapter,

--- a/src/complete/sdk.cpp
+++ b/src/complete/sdk.cpp
@@ -373,11 +373,17 @@ std::string_view GameInstanceAdapter::GetModeName() const
 
 void GameInstanceAdapter::Setup()
 {
+    rallyhere::string bootstrapMode{};
+    rallyhere::string provider{};
     m_UserAgent = BOOST_BEAST_VERSION_STRING;
     for (auto&& arg : m_Arguments)
     {
         rallyhere::string tmp;
-        if (ParseArgument("rhbootstrapmode=", arg, m_ModeName))
+        if (ParseArgument("rhbootstrapmode=", arg, bootstrapMode))
+        {
+            continue;
+        }
+        if (ParseArgument("ghaprovider=", arg, provider))
         {
             continue;
         }
@@ -635,6 +641,15 @@ void GameInstanceAdapter::Setup()
     m_SslContext.set_verify_mode(ssl::context::verify_none);
     m_SslContext.set_default_verify_paths();
     boost::certify::enable_native_https_server_verification(m_SslContext);
+    if (!provider.empty())
+    {
+        m_ModeName = provider;
+    }
+    else
+    {
+        m_ModeName = bootstrapMode;
+    }
+    log().log(RH_LOG_LEVEL_INFO, "Chosen mode: {} from bootstrap: {} or provider: {}", m_ModeName, bootstrapMode, provider);
     if (m_ModeName == "SIC")
     {
         SetupSIC();

--- a/src/complete/sdk.cpp
+++ b/src/complete/sdk.cpp
@@ -163,7 +163,7 @@ void GameInstanceAdapter::Connect(base_callback_function_t callback, void* user_
         ConnectSIC(callback, user_data);
     else if (m_ModeName == "Multiplay")
         ConnectMultiplay(callback, user_data);
-    else if (m_ModeName == "AutoCreate")
+    else if (m_ModeName == "AutoCreate" || m_ModeName == "None")
     {
         if (callback)
             callback(RH_STATUS_OK, user_data);
@@ -179,7 +179,7 @@ void GameInstanceAdapter::Ready(base_callback_function_t callback, void* user_da
         ReadySIC(callback, user_data);
     else if (m_ModeName == "Multiplay")
         ReadyMultiplay(callback, user_data);
-    else if (m_ModeName == "AutoCreate")
+    else if (m_ModeName == "AutoCreate" || m_ModeName == "None")
     {}
     else
         if (callback)
@@ -658,7 +658,7 @@ void GameInstanceAdapter::Setup()
     {
         SetupMultiplay();
     }
-    else if (m_ModeName == "AutoCreate")
+    else if (m_ModeName == "AutoCreate" || m_ModeName == "None")
     {}
     else
     {

--- a/src/complete/sdk.h
+++ b/src/complete/sdk.h
@@ -387,6 +387,13 @@ class GameInstanceAdapter
     {
         m_FakeAllocationData = data;
     }
+    auto GetPublicHostAndPort() const
+    {
+        auto allocation_info = i3d::one::allocator::create<rallyhere::StringMap>();
+        allocation_info->Set("public_host", m_SicPublicHost);
+        allocation_info->Set("public_port", m_PublicPort);
+        return allocation_info;
+    }
 
   private:
     /** Inform the game host that this game instance is done with its current allocation. Should only be called as part of the destruction of

--- a/src/complete/sdk_multiplay.cpp
+++ b/src/complete/sdk_multiplay.cpp
@@ -167,6 +167,8 @@ void GameInstanceAdapter::ReadyMultiplay(base_callback_function_t callback, void
 
 void GameInstanceAdapter::CheckServerJson()
 {
+    if (!m_MultiplayServerFileWatcher)
+        return;
     auto source = LoadFileToString(m_MultiplayServerFile);
     boost::json::error_code ec;
     custom_resource mr;

--- a/src/complete/sdk_multiplay.cpp
+++ b/src/complete/sdk_multiplay.cpp
@@ -200,7 +200,10 @@ void GameInstanceAdapter::CheckServerJson()
             allocation_info->Set("public_port", m_AllocatedPublicPort);
             if (LastAllocatedGauge)
                 LastAllocatedGauge->SetToCurrentTime();
-            m_OnAllocatedCallback(reinterpret_cast<RallyHereStringMapPtr>(allocation_info), RH_STATUS_OK, m_OnAllocatedUserData);
+            if (m_OnAllocatedCallback)
+                m_OnAllocatedCallback(reinterpret_cast<RallyHereStringMapPtr>(allocation_info), RH_STATUS_OK, m_OnAllocatedUserData);
+            else
+                i3d::one::allocator::destroy(allocation_info);
             StopCheckingServerJson();
         }
     }

--- a/test/c_interface/test_multiplay.cpp
+++ b/test/c_interface/test_multiplay.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "test_multiplay.h"
 #include "c_api.h"
 #include "rh_allocator.h"
+#include <thread>
 
 #include "boost/scope_exit.hpp"
 
@@ -347,6 +348,7 @@ static const lest::test module[] = {
                      "\"ConnectionIP\":\"thegreatest.game.com\","
                      "\"ConnectionPort\":\"6767\"}\n");
         }
+        std::this_thread::sleep_for(std::chrono::seconds(1));
         start = std::chrono::steady_clock::now();
         while (!data.allocated_called)
         {

--- a/test/c_interface/test_sic.cpp
+++ b/test/c_interface/test_sic.cpp
@@ -539,7 +539,36 @@ static const lest::test module[] = {
         rallyhere_ready(adapter, on_ready_callback, &data);
         EXPECT(data.ready_result == RH_STATUS_PROMETHEUS_COULD_NOT_START);
     },
+    CASE("SIC C interface reserve can get public host and port")
+    {
+        auto arguments_source = get_default_arguments<rallyhere::string>();
+        SETUP_TEST_ADAPTER;
+        ADAPTER_CONNECT;
+
+        rallyhere_reserve_unconditional(adapter, on_reserve_callback, &data);
+
+        ADAPTER_HEALTHY;
+        ADAPTER_TICK;
+
+        RallyHereStringMapPtr hostinfo = nullptr;
+        BOOST_SCOPE_EXIT_ALL(hostinfo) {
+            rallyhere_string_map_destroy(hostinfo);
+        };
+        rallyhere_get_public_host_and_port(adapter, &hostinfo);
+        EXPECT(hostinfo != nullptr);
+        const char* value_to_check = nullptr;
+        unsigned int value_size = 0;
+        EXPECT(rallyhere_string_map_get(hostinfo, "public_host", &value_to_check, &value_size) == RH_STATUS_OK);
+        const char* expected_hostname = "unknownhostname";
+        EXPECT(value_size == strlen(expected_hostname));
+        EXPECT(0 == strcmp(expected_hostname, value_to_check));
+        const char* expected_port = "9000";
+        EXPECT(rallyhere_string_map_get(hostinfo, "public_port", &value_to_check, &value_size) == RH_STATUS_OK);
+        EXPECT(value_size == strlen(expected_port));
+        EXPECT(0 == strcmp(expected_port, value_to_check));
+    },
 };
+
 //@formatter:on
 // clang-format off
 

--- a/test/complete/test_provider.cpp
+++ b/test/complete/test_provider.cpp
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 RallyHere
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "test_sic.h"
+#include "allocator.h"
+#include "sdk.h"
+#include "c_api.h"
+
+#include "rh_vector.h"
+#include "rh_string.h"
+
+#include "boost/scope_exit.hpp"
+#include "boost/filesystem.hpp"
+
+#include "shared_test_data.h"
+#include "configuration.h"
+
+template<typename T>
+auto get_default_arguments(rallyhere::string bootstrap, rallyhere::string provider)
+{
+    std::stringstream sstr;
+    sstr << get_credentials_file_path_arg() << " " << get_rally_here_url_arg() << " " << get_rh_credentials_as_arg();
+    if (!bootstrap.empty())
+    {
+        sstr << " -rhbootstrapmode=" << bootstrap;
+    }
+    if (!provider.empty())
+    {
+        sstr << " -ghaprovider=" << provider;
+    }
+    return sstr.str();
+}
+
+//@formatter:off
+// clang-format off
+static const lest::test module[] = {
+    CASE("Bootstrap SIC is correct")
+    {
+        auto arguments = get_default_arguments<const char *>("SIC", "");
+        rallyhere::GameInstanceAdapter adapter{arguments.c_str()};
+        auto mode_name = adapter.GetModeName();
+        EXPECT(mode_name == "SIC");
+    },
+    CASE("Provider SIC is correct")
+    {
+        auto arguments = get_default_arguments<const char *>("AutoCreate", "SIC");
+        rallyhere::GameInstanceAdapter adapter{arguments.c_str()};
+        auto mode_name = adapter.GetModeName();
+        EXPECT(mode_name == "SIC");
+    },
+    CASE("Provider SIC is correct if bootstrap is multiplay")
+    {
+        auto arguments = get_default_arguments<const char *>("Multiplay", "SIC");
+        rallyhere::GameInstanceAdapter adapter{arguments.c_str()};
+        auto mode_name = adapter.GetModeName();
+        EXPECT(mode_name == "SIC");
+    },
+    CASE("Provider SIC is correct if bootstrap is set to unknown")
+    {
+        auto arguments = get_default_arguments<const char *>("WallaWalla", "SIC");
+        rallyhere::GameInstanceAdapter adapter{arguments.c_str()};
+        auto mode_name = adapter.GetModeName();
+        EXPECT(mode_name == "SIC");
+    },
+};
+//@formatter:on
+// clang-format off
+
+extern lest::tests& specification();
+
+MODULE( specification(), module );

--- a/test/complete/test_provider.cpp
+++ b/test/complete/test_provider.cpp
@@ -74,6 +74,13 @@ static const lest::test module[] = {
         auto mode_name = adapter.GetModeName();
         EXPECT(mode_name == "SIC");
     },
+    CASE("Provider None is available")
+    {
+        auto arguments = get_default_arguments<const char *>("None", "");
+        rallyhere::GameInstanceAdapter adapter{arguments.c_str()};
+        auto mode_name = adapter.GetModeName();
+        EXPECT(mode_name == "None");
+    },
 };
 //@formatter:on
 // clang-format off

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "game-host-adapter",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "homepage": "https://github.com/RallyHereInteractive/game-host-adapter",
   "builtin-baseline": "c9140a3b500812ad3206317885860d9553b93f13",
   "dependencies": [


### PR DESCRIPTION
Adds a new API call `rallyhere_get_public_host_and_port` which gets the host and port values as they're understand by SIC. This enables reusing the RallyHere deployment information without relying on SIC for an allocation.

Add a new command line argument ghaprovider. When provided this will be the value that is use to determine the mode. This enables instances to use rhbootstrapmode to specify other behaviors.

Added an explicit "None" provider that doesn't do anything.

Fixed a segfault when Multiplay is registered twice within the same tick.